### PR TITLE
Try to fix the further issues in #107, asterisks inserted by etherpad in the markup breaking the HTML layout

### DIFF
--- a/cl/web.py
+++ b/cl/web.py
@@ -253,7 +253,10 @@ def default(path=''):
                     rec.data['content'] = c.text
                     rec.save()
             cont = rec.data.get('content','').encode('utf-8').decode('utf-8').replace(u'Â','') # works. leave it.
-            cont = re.sub('\*<', '<', cont )
+            # etherpads insert asterisks (*) sometimes when they see \t tabs, bless 'em
+            cont = re.sub('\*<', '<', cont ) # it can break HTML tags
+            cont = re.sub('(^\s*\*\s*$)', '', cont) # still get stand-alone * on blank lines with tabs in them
+
             content += markdown.markdown( cont )
 
             # if an embedded file url has been provided, embed it in the content too


### PR DESCRIPTION
Some tests of the new regex introduced to handle stand-alone asterisks:

``` python
test_str1 = '*<div>test</div>'
re.sub('(^\s*\*\s*$)', '', test_str1)
# '*<div>test</div>'
# that's right, the other regex touches this, so this one should leave it alone

test_str2 = '*'
re.sub('(^\s*\*\s*$)', '', test_str2)
# ''

test_str3 = ' *     '
re.sub('(^\s*\*\s*$)', '', test_str3)
# ''

# test some normal use cases for asterisks, make sure not to break normal usage
test_str4 = '* list item'
re.sub('(^\s*\*\s*$)', '', test_str4)
# '* list item'

test_str5 = '    * indented list item'
re.sub('(^\s*\*\s*$)', '', test_str5)
# '    * indented list item'

# seems like we're only deleting stand-alone ones, good
```
