### PR TITLE
override Bootstrap styling of <abbr> for our use

### DIFF
--- a/portality/static/css/style.css
+++ b/portality/static/css/style.css
@@ -18,6 +18,10 @@ p {
     line-height:22px;
 }
 
+abbr {
+    border-bottom-color: #000;
+}
+
 .thumbnail{
     margin:5px;
 }


### PR DESCRIPTION
Bootstrap's #DDD colour is almost invisible with our current background,
making <abbr> less useful from a UI perspective. The dotted underline
affords hovering, so the user can see the definition (title attribute)
of whatever was put inside a pair of <abbr> tags.
